### PR TITLE
refactor(Annotation): replace basename-based class name extraction wi…

### DIFF
--- a/src/Annotation.php
+++ b/src/Annotation.php
@@ -11,42 +11,26 @@
 
 namespace Rudra\Annotation;
 
-use Rudra\Exceptions\LogicException;
-
 class Annotation implements AnnotationInterface
 {
     /**
-     * ----------------------
      * Parameter separator
-     * ----------------------
-     * Разделитель параметров
-     * ----------------------
      * 
-     * --------------------------------------------------------
      * in the line  ',', example: key='param', key2='param2'
      * in the array ';', example: {key:'param'; key2:'param2'}
-     * --------------------------------------------------------
      */
     public const array DELIMITER = ["string" => ',', "array" => ';'];
 
     /**
-     * -----------------
      * Assignment mark
-     * -----------------
-     * Знак присваивания
-     * -----------------
      * 
-     * ----------------------------------------
      * in the line  '=', example: key='param'
      * in the array ':', example: {key:'param'}
-     * ----------------------------------------
      */
     public const array ASSIGNMENT = ["string" => '=', "array" => ':'];
 
     /**
-     * @param  string      $className
-     * @param  string|null $methodName
-     * @return array
+     * Each parameter must be on its own line.
      */
     #[\Override]
     public function getAnnotations(string $className, ?string $methodName = null): array
@@ -61,17 +45,12 @@ class Annotation implements AnnotationInterface
     }
 
     /**
-     * @param  string $className
-     * @param  string|null $methodName
-     * @return array
+     * Returns all attributes for a class or method.
+     * Returns short class names (e.g. `Cache`, not `App\Attributes\Cache`).
      */
     #[\Override]
     public function getAttributes(string $className, ?string $methodName = null): array
     {
-        if (PHP_VERSION_ID < 80000) {
-            throw new LogicException('Attributes are only supported in PHP 8.0 and above.');
-        }
-
         $reflection = $this->getReflection($className, $methodName);
         $attributes = [];
 
@@ -83,20 +62,12 @@ class Annotation implements AnnotationInterface
         return $attributes;
     }
 
-    /**
-     * @param  string $fullyQualifiedName
-     * @return string
-     */
     private function extractShortClassName(string $fullyQualifiedName): string
     {
-        return substr($fullyQualifiedName, (int) strrpos($fullyQualifiedName, '\\') + 1);
+        $pos = strrpos($fullyQualifiedName, '\\');
+        return $pos === false ? $fullyQualifiedName : substr($fullyQualifiedName, $pos + 1);
     }
 
-    /**
-     * @param  string      $className
-     * @param  string|null $methodName
-     * @return \ReflectionClass|\ReflectionMethod
-     */
     private function getReflection(string $className, ?string $methodName = null): \ReflectionClass|\ReflectionMethod
     {
         return $methodName !== null
@@ -104,33 +75,23 @@ class Annotation implements AnnotationInterface
             : new \ReflectionClass($className);
     }
 
-    /**
-     * @param string $docBlock
-     * @return array
-     */
     private function parseAnnotations(string $docBlock): array
     {
         $annotations = [];
 
         /**
-         * --------------------------------------------------------------------------------------
          * $matches[0][0] - @Annotation(param1, param2='param2', param3={param1;param2:'param2'})
          * $matches[1][0] - Annotation         
          * $matches[2][0] - param1, param2 = 'param2', param3={param1;param2:'param2'}
-         * --------------------------------------------------------------------------------------
          */
-        if (preg_match_all("/@([A-Za-z_-]+)\((.*)?\)/", $docBlock, $matches)) {
+        if (preg_match_all("/@([A-Za-z0-9_-]+)\((.*?)\)/", $docBlock, $matches)) {
             $count = count($matches[0]);
             $extractor = new ParamsExtractor();
 
-            /**
-             * ----------------------------------------------------------------------------------------------------------------------
-             * $annotations = ["Annotation" => [[0 => "param1", "param2" => "param2", "param3" => ["param1", "param2" => "param2"]]]]
-             * ----------------------------------------------------------------------------------------------------------------------
-             */
+            // $annotations = ["Annotation" => [[0 => "param1", "param2" => "param2", "param3" => ["param1", "param2" => "param2"]]]]
             for ($i = 0; $i < $count; $i++) {
                 $annotations[$matches[1][$i]][] = $extractor->getParams(
-                    str_getcsv(trim($matches[2][$i]), self::DELIMITER["string"]),
+                    str_getcsv(trim($matches[2][$i]), self::DELIMITER["string"], '"', ''),
                     self::ASSIGNMENT["string"]
                 );
             }

--- a/src/AnnotationInterface.php
+++ b/src/AnnotationInterface.php
@@ -13,17 +13,6 @@ namespace Rudra\Annotation;
 
 interface AnnotationInterface
 {
-    /**
-     * @param  string      $className 
-     * @param  string|null $methodName
-     * @return array
-     */
     public function getAnnotations(string $className, ?string $methodName = null): array;
-
-    /**
-     * @param  string      $className
-     * @param  string|null $methodName
-     * @return array
-     */
     public function getAttributes(string $className, ?string $methodName = null): array;
 }

--- a/src/ParamsExtractor.php
+++ b/src/ParamsExtractor.php
@@ -14,16 +14,10 @@ namespace Rudra\Annotation;
 class ParamsExtractor
 {
     /**
-     * --------------------------------------------------------------
      * Parses an array of parameter strings into an associative array
-     * --------------------------------------------------------------
-     * Преобразует массив строк с параметрами в ассоциативный массив
-     * --------------------------------------------------------------
      * 
-     * ------------------------------------------------------------------------------------
      * `from: "param1, param2 = 'param2', param3={param1;param2:'param2'}"`
      * `to: ["param1", "param2" => "param2", "param3" => ["param1", "param2" => "param2"]]`
-     * ------------------------------------------------------------------------------------
      * 
      * @param  array  $exploded
      * @param  string $assignment
@@ -45,35 +39,16 @@ class ParamsExtractor
     }
 
     /**
-     * --------------------------------------------
      * Parses data into `key => value` pairs
-     * --------------------------------------------
-     * Преобразует данные в пары `ключ => значение`
-     * --------------------------------------------
      * 
-     * ⚠️ IMPORTANT / ВАЖНО:
-     * --------------------------------------------
-     * Values inside arrays (curly braces) must not
-     * contain the array assignment mark (`:`)
-     * --------------------------------------------
-     * Значения внутри массивов (фигурные скобки)
-     * не должны содержать знак присваивания (`:`)
-     * --------------------------------------------
+     * ⚠️ IMPORTANT: Values inside arrays (curly braces) 
+     * must not contain the array assignment mark (`:`)
      * 
-     * @param  string $data
-     * @param  array  $exploded
-     * @return array|null
      * @codeCoverageIgnore
      */
     private function handleData(string $data, array $exploded): ?array
     {
-        /**
-         * --------------------------------------------------------------
-         * If in data an array of type param3={param1;param2:'param2'}
-         * --------------------------------------------------------------
-         * Если в данных есть массив типа param3={param1;param2:'param2'}
-         * --------------------------------------------------------------
-         */
+        // If in data an array of type param3={param1;param2:'param2'}
         if (preg_match("/=\s*{/", $data) && preg_match("/{(.*)}/", $exploded[1], $matches)) {
             return [
                 trim($exploded[0]) => $this->getParams(
@@ -84,15 +59,8 @@ class ParamsExtractor
         }
 
         /**
-         * ---------------------------------------
          * Remove quotation marks around parameter
-         * ---------------------------------------
-         * Удаляет кавычки вокруг параметра
-         * ---------------------------------------
-         * 
-         * ----------------------
          * matches[1] = 'param2';
-         * ----------------------
          */
         if (preg_match("/'(.*)'/", $exploded[1], $matches)) {
             return [trim($exploded[0]) => $matches[1]];


### PR DESCRIPTION
…th safer logic

- Use strrpos() + substr() instead of basename(strtr()) to reliably extract short class names from fully qualified names, including edge cases like namespaced classes without backslashes or trailing separators.